### PR TITLE
Query planner breaks on top-level edges that resolve to builtin scalars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ fastrand = "1.4.0"
 async-stream = "0.3.0"
 futures-util = "0.3.13"
 
+[[example]]
+name = "builtin_scalar_bug"
+path = "./examples/builtin_scalar_bug/bug.rs"
+
 [workspace]
 members = [
     "crates/schema",

--- a/crates/planner/tests/query.txt
+++ b/crates/planner/tests/query.txt
@@ -8,6 +8,7 @@
     u2: user(id: "1234") {
         id username
     }
+    myName
 }
 ---
 {}
@@ -15,5 +16,5 @@
 {
     "type": "fetch",
     "service": "accounts",
-    "query": "query { u1:user(id: \"1234\") { id username } me { id username } u2:user(id: \"1234\") { id username } }"
+    "query": "query { u1:user(id: \"1234\") { id username } me { id username } u2:user(id: \"1234\") { id username } myName }"
 }

--- a/crates/planner/tests/test.graphql
+++ b/crates/planner/tests/test.graphql
@@ -16,6 +16,7 @@ schema
 }
 
 type Query {
+    myName: String! @resolve(service: "accounts")
     me: User @resolve(service: "accounts")
     user(id: ID!): User @resolve(service: "accounts")
     topProducts: [Product!]! @resolve(service: "products")

--- a/crates/schema/src/composed_schema.rs
+++ b/crates/schema/src/composed_schema.rs
@@ -654,7 +654,7 @@ fn finish_schema(composed_schema: &mut ComposedSchema) {
         match definition {
             TypeSystemDefinition::Type(type_definition) => {
                 let mut type_definition = convert_type_definition(type_definition.node);
-                type_definition.is_introspection = true;
+                type_definition.is_introspection = false;
                 composed_schema
                     .types
                     .insert(type_definition.name.clone(), type_definition);

--- a/examples/builtin_scalar_bug/bug.rs
+++ b/examples/builtin_scalar_bug/bug.rs
@@ -1,0 +1,87 @@
+use std::convert::Infallible;
+
+use async_graphql::{
+    Context, EmptyMutation, EmptySubscription, Object, Schema, SimpleObject, Subscription, ID,
+};
+use async_graphql_warp::{graphql, graphql_subscription};
+use futures_util::stream::Stream;
+use serde::{Deserialize, Serialize};
+use tokio::time::Duration;
+use warp::{Filter, Reply};
+
+// Run the service:
+// ```
+// $ cargo run --example builtin_scalar_bug
+// ```
+//
+// Run the gateway:
+// ```
+// $ cargo run -- ./examples/builtin_scalar_bug/config.toml
+// ```
+//
+// Query the service directly:
+// ```
+// $ curl -s 'http://localhost:8001' --data-binary '{"query":"{ builtinScalar customScalar }\n"}' | jq .data
+// {
+//   "builtinScalar": "Hi, I'm builtin",
+//   "customScalar": "Hi, I'm custom"
+// }
+// ```
+//
+// Run the same query through the gateway:
+// ```
+// $ curl -s 'http://localhost:8000' --data-binary '{"query":"{ builtinScalar customScalar }\n"}' | jq .data
+// {
+//   "builtinScalar": null,
+//   "customScalar": "Hi, I'm custom"
+// }
+// ```
+//
+// :(
+
+#[derive(Serialize, Deserialize)]
+struct CustomString(String);
+async_graphql::scalar!(CustomString);
+
+struct Query;
+
+#[Object(extends)]
+impl Query {
+    async fn builtin_scalar(&self) -> String {
+        "Hi, I'm builtin".into()
+    }
+    async fn custom_scalar(&self) -> CustomString {
+        CustomString("Hi, I'm custom".into())
+    }
+
+    #[graphql(entity)] // just so we get _service
+    async fn find_me(&self, constant: String) -> BuiltinScalarBug {
+        BuiltinScalarBug { constant }
+    }
+}
+
+#[derive(SimpleObject)]
+struct BuiltinScalarBug {
+    constant: String,
+}
+
+#[tokio::main]
+async fn main() {
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription).finish();
+
+    let routes = graphql(schema.clone())
+        .and(warp::post())
+        .and_then(
+            |(schema, request): (
+                Schema<Query, EmptyMutation, EmptySubscription>,
+                async_graphql::Request,
+            )| async move {
+                Ok::<_, Infallible>(
+                    warp::reply::json(&schema.execute(request).await).into_response(),
+                )
+            },
+        )
+        .or(graphql_subscription(schema));
+
+    warp::serve(routes).run(([0, 0, 0, 0], 8001)).await;
+}

--- a/examples/builtin_scalar_bug/config.toml
+++ b/examples/builtin_scalar_bug/config.toml
@@ -1,0 +1,5 @@
+bind = "0.0.0.0:8000"
+
+[[services]]
+name = "builtin_scalar_bug"
+addr = "127.0.0.1:8001"


### PR DESCRIPTION
Hey @sunli829,

First of all: a big thank you for all the work that you've put in https://github.com/async-graphql/async-graphql, it's been an absolute joy to work with and dig into the code.
It's a fantastic piece of software overall and `graphgate` is shaping up to be no different :upside_down_face:  :pray:

---

Now, regarding the issue at hand: I've been hitting a bug in `graphgate`'s where it seems impossible to extends the global `Query` object with edges that resolve to builtin scalar types.

I.e., [consider a simple service like this one](https://github.com/znly/graphgate/blob/da2e1603f1bd0f01ddb08ddf026989a762132870/examples/builtin_scalar_bug/bug.rs):
```rust
#[derive(Serialize, Deserialize)]
struct CustomString(String);
async_graphql::scalar!(CustomString);

struct Query;

#[Object(extends)]
impl Query {
    async fn builtin_scalar(&self) -> String {
        "Hi, I'm builtin".into()
    }
    async fn custom_scalar(&self) -> CustomString {
        CustomString("Hi, I'm custom".into())
    }

    #[graphql(entity)] // just so we get _service
    async fn find_me(&self, constant: String) -> BuiltinScalarBug {
        BuiltinScalarBug { constant }
    }
}

#[derive(SimpleObject)]
struct BuiltinScalarBug {
    constant: String,
}
```

Querying this service directly behaves as you'd expect:
```sh
$ curl -s 'http://localhost:8001'  -H 'Content-Type: application/json' --data-binary '{"query":"{ builtinScalar customScalar }\n"}' | jq .data
```
```json
{
  "builtinScalar": "Hi, I'm builtin",
  "customScalar": "Hi, I'm custom"
}
```

But as soon as you go through `graphgate`, things go awry and the `builtinScalar` edge starts misbehaving:
```sh
$ curl -s 'http://localhost:8000'  -H 'Content-Type: application/json' --data-binary '{"query":"{ builtinScalar customScalar }\n"}' | jq .data
```
```json
{
  "builtinScalar": null,
  "customScalar": "Hi, I'm custom"
}
```

---

The issue seems to stem from the query planner's handling of builtin scalar types, and [more specifically this part](https://github.com/znly/graphgate/blob/cmc/builtin_scalar_bug/crates/planner/src/builder.rs#L163-L166):
```rust
if field_type.is_introspection {
    ctx.build_introspection_field(inspection_selection_set, &field.node);
    continue;
}
```
which for some reason I don't yet fully understand turns what should have been a `Fetch` plan into an `Introspection` plan, hence the `null` data we ultimately get in return.

The `is_introspection` boolean seems to only ever be used for this specific check, and [is only ever set in the code that builds the `ComposedSchema`](https://github.com/znly/graphgate/blob/cmc/builtin_scalar_bug/crates/schema/src/composed_schema.rs#L649-L670), for all builtin scalar types:
```rust
    for definition in parser::parse_schema(include_str!("builtin.graphql"))
        .unwrap()
        .definitions
        .into_iter()
    {
        match definition {
            TypeSystemDefinition::Type(type_definition) => {
                let mut type_definition = convert_type_definition(type_definition.node);
                type_definition.is_introspection = true;
                composed_schema
                    .types
                    .insert(type_definition.name.clone(), type_definition);
            }
            TypeSystemDefinition::Directive(directive_definition) => {
                composed_schema.directives.insert(
                    directive_definition.node.name.node.clone(),
                    convert_directive_definition(directive_definition.node),
                );
            }
            TypeSystemDefinition::Schema(_) => {}
        }
    }
```

Completely disabling the notion of `is_introspection` fixes the issue and doesn't break any test:
```diff
- type_definition.is_introspection = true;
+ type_definition.is_introspection = false;
```
though this is obviously not the right course of action (also it breaks real introspection queries :smile:).

---

This PR isn't meant to be merged as-is, it's more of a demo of the issue:
- the first commit contains the example described above,
- the second commit modifies the test suite of the query planner to make it fail on this specific issue,
- the third commit completely removes the notion of `is_introspection`, which fixes the issue and makes the examples and test suite pass, but is definitely not the right thing to do.

Hope this helps & happy to answer any questions.

Cheers!