### PR TITLE
Allow a different path for introspection requests

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,7 @@ name = "accounts"               # Service name
 addr = "127.0.0.1:8001"         # Service address
 query_path = "/"                # GraphQL query endpoint, Default: /
 subscribe_path = "/"            # GraphQL subscription endpoint, Default: /
+introspection_path = "/"        # GraphQL introspection path, Default: /
 
 [[services]]
 name = "products"
@@ -26,4 +27,3 @@ addr = "127.0.0.1:8002"
 [[services]]
 name = "reviews"
 addr = "127.0.0.1:8003"
-

--- a/crates/handler/src/fetcher.rs
+++ b/crates/handler/src/fetcher.rs
@@ -31,7 +31,7 @@ impl<'a> HttpFetcher<'a> {
 impl<'a> Fetcher for HttpFetcher<'a> {
     async fn query(&self, service: &str, request: Request) -> Result<Response> {
         self.router_table
-            .query(service, request, Some(self.header_map))
+            .query(service, request, Some(self.header_map), None)
             .await
     }
 }

--- a/crates/handler/src/shared_route_table.rs
+++ b/crates/handler/src/shared_route_table.rs
@@ -100,7 +100,7 @@ impl SharedRouteTable {
             let route_table = route_table.clone();
             async move {
                 let resp = route_table
-                    .query(service, Request::new(QUERY_SDL), None)
+                    .query(service, Request::new(QUERY_SDL), None, Some(true))
                     .await
                     .with_context(|| format!("Failed to fetch SDL from '{}'.", service))?;
                 let resp: ResponseQuery =

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ pub struct ServiceConfig {
     pub tls: bool,
     pub query_path: Option<String>,
     pub subscribe_path: Option<String>,
+    pub introspection_path: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -44,6 +45,7 @@ impl Config {
                     tls: service.tls,
                     query_path: service.query_path.clone(),
                     subscribe_path: service.subscribe_path.clone(),
+                    introspection_path: service.introspection_path.clone(),
                 },
             );
         }

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -9,6 +9,7 @@ const LABEL_GRAPHQL_SERVICE: &str = "graphgate.org/service";
 const ANNOTATIONS_TLS: &str = "graphgate.org/tls";
 const ANNOTATIONS_QUERY_PATH: &str = "graphgate.org/queryPath";
 const ANNOTATIONS_SUBSCRIBE_PATH: &str = "graphgate.org/subscribePath";
+const ANNOTATIONS_INTROSPECTION_PATH: &str = "graphgate.org/introspectionPath";
 
 fn get_label_value<'a>(meta: &'a ObjectMeta, name: &str) -> Option<&'a str> {
     meta.labels
@@ -63,6 +64,8 @@ pub async fn find_graphql_services() -> Result<ServiceRouteTable> {
                 let query_path = get_annotation_value(&service.metadata, ANNOTATIONS_QUERY_PATH);
                 let subscribe_path =
                     get_annotation_value(&service.metadata, ANNOTATIONS_SUBSCRIBE_PATH);
+                let introspection_path =
+                    get_annotation_value(&service.metadata, ANNOTATIONS_INTROSPECTION_PATH);
                 route_table.insert(
                     service_name.to_string(),
                     ServiceRoute {
@@ -70,6 +73,7 @@ pub async fn find_graphql_services() -> Result<ServiceRouteTable> {
                         tls,
                         query_path: query_path.map(ToString::to_string),
                         subscribe_path: subscribe_path.map(ToString::to_string),
+                        introspection_path: introspection_path.map(ToString::to_string),
                     },
                 );
             }


### PR DESCRIPTION
This PR allows users to define an optional introspection path to be used for querying for federated schemas from services. This is useful when regular query endpoints such as `/graphql` require authentication. 

config toml can now be configured as follows:

```toml 
[[services]]
name = "accounts"                            # Service name
addr = "127.0.0.1:8001"                      # Service address
query_path = "/"                             # GraphQL query endpoint, Default: /
subscribe_path = "/"                         # GraphQL subscription endpoint, Default: /
introspection_path = "/introspection"        # GraphQL introspection path, Default: /
```
