### PR TITLE
Skip nullable external fields rather than attempting to resolve

### DIFF
--- a/crates/handler/src/executor.rs
+++ b/crates/handler/src/executor.rs
@@ -244,7 +244,6 @@ impl<'e> Executor<'e> {
             possible_type: Option<&str>,
         ) -> Representation {
             let prefix = format!("__key{}_", prefix);
-
             if let Some(possible_type) = possible_type {
                 match from.get(format!("{}__typename", prefix).as_str()) {
                     Some(ConstValue::String(typename)) if typename == possible_type => {}
@@ -289,6 +288,8 @@ impl<'e> Executor<'e> {
                                 prefix,
                                 segment.possible_type,
                             ));
+                        } else {
+                            representations.push(Representation::Skip);
                         }
                     }
                     ConstValue::Object(object) if segment.is_list => {
@@ -300,6 +301,8 @@ impl<'e> Executor<'e> {
                                         prefix,
                                         segment.possible_type,
                                     ));
+                                } else {
+                                    representations.push(Representation::Skip);
                                 }
                             }
                         }
@@ -311,6 +314,8 @@ impl<'e> Executor<'e> {
                     ConstValue::Object(object) if !segment.is_list => {
                         if let Some(next_value) = object.get_mut(segment.name) {
                             get_representations(representations, next_value, &path[1..], prefix);
+                        } else {
+                            representations.push(Representation::Skip);
                         }
                     }
                     ConstValue::Object(object) if segment.is_list => {
@@ -318,6 +323,8 @@ impl<'e> Executor<'e> {
                             for element in array {
                                 get_representations(representations, element, &path[1..], prefix);
                             }
+                        } else {
+                            representations.push(Representation::Skip);
                         }
                     }
                     _ => {}
@@ -336,7 +343,6 @@ impl<'e> Executor<'e> {
                 None => return,
             };
             let is_last = path.len() == 1;
-
             if is_last {
                 match target {
                     ConstValue::Object(object) if !segment.is_list => {


### PR DESCRIPTION
Hi @sunli829, 

I am looking for some guidance on this PR. I've been coming across an issue in Graphgate where it has issues resolving external fields which are nullable. For a query like 

``` graphql
query {
  # newsfeed and its articles are returned from service A
  newsfeed {
    articles {
      id
      # actor for article is nullable and is returned from service B as an external field
      actor {
        id 
        firstName
        lastName
      }
    }
  }
}
```
given this scenario, if this example query returns 3 articles two of which have  an actor and the middle article has a null actor then Graphgate still attempts to populate the fields from all three articles, even though Service B is only returning two entities for the external fields. 

The result might look something like this:

``` json 
{
  "data": {
    "newsfeed": {
      "articles": [{
          "id": 1 "actor": {
            "id": 1,
            "firstName": "John",
            "lastName": "Doe"
          }
        },
        {
          "id": "2"
          "actor": {
            "firstName": "Alan",
            "lastName": "Smith"
          }
        },
        {
          "id": "3",
          "actor": {
            "id": 2,
          }
        }
      ]
    }
  }

}
```

The actor for article with id: 2 should be NULL, however we can see its been populated with some fields from the third actor, and the third actor has incomplete fields as a result. 

The correct result should look like: 

``` json 
{
  "data": {
    "newsfeed": {
      "articles": [{
          "id": 1 "actor": {
            "id": 1,
            "firstName": "John",
            "lastName": "Doe"
          }
        },
        {
          "id": "2"
          "actor": NULL
        },
        {
          "id": "3",
          "actor": {
            "id": 2,
            "firstName": "Alan",
            "lastName": "Smith"
          }
        }
      ]
    }
  }
}
```

I initially thought this was an issue with downstream services returning incorrect entities however this can be reproduced with a minimal example. This only affects types where the field is nullable. 

This PR includes code which i believe fixes the issue. I believe the issue is caused when the executor attempts to match up entities to their object in the graph, if there is no match for the object then the executor simply does nothing rather than skipping the field. 
