### PR TITLE
Process interface implimenters for query fields

### DIFF
--- a/crates/planner/src/builder.rs
+++ b/crates/planner/src/builder.rs
@@ -721,17 +721,15 @@ impl<'a> Context<'a> {
                         if let Some(fragment) =
                             ctx.fragments.get(&fragment_spread.node.fragment_name.node)
                         {
-                            if fragment.node.type_condition.node.on.node == current_ty {
-                                build_fields(
-                                    ctx,
-                                    path,
-                                    selection_ref_set_group,
-                                    fetch_entity_group,
-                                    current_service,
-                                    &fragment.node.selection_set.node,
-                                    possible_type,
-                                );
-                            }
+                            build_fields(
+                                ctx,
+                                path,
+                                selection_ref_set_group,
+                                fetch_entity_group,
+                                current_service,
+                                &fragment.node.selection_set.node,
+                                possible_type,
+                            );
                         }
                     }
                     Selection::InlineFragment(inline_fragment) => {

--- a/crates/planner/tests/fragment_on_interface.txt
+++ b/crates/planner/tests/fragment_on_interface.txt
@@ -1,0 +1,31 @@
+fragment AccountDetails on StoreAccount {
+       __typename
+      ... on PersonalAccount {
+        deliveryName
+        dob
+      }
+      ... on BusinessAccount {
+        taxNumber
+        businessSector
+      }
+    }
+
+{
+    me {
+        id
+        username
+        storeAccount {
+          id
+          createdAt
+        ...AccountDetails
+    }
+}
+}
+---
+{}
+---
+{
+    "type": "fetch",
+    "service": "accounts",
+    "query": "query { me { id username storeAccount { ... on PersonalAccount { id createdAt __typename deliveryName dob } ... on BusinessAccount { id createdAt __typename taxNumber businessSector } } } }"
+}

--- a/crates/planner/tests/test.graphql
+++ b/crates/planner/tests/test.graphql
@@ -47,6 +47,7 @@ type User
     username: String!
     reviews: [Review]! @resolve(service: "reviews")
     products: [Product]! @resolve(service: "products")
+    storeAccount: StoreAccount!
 }
 
 interface Product {
@@ -54,6 +55,30 @@ interface Product {
     name: String!
     price: Int!
     reviews: [Review]! @resolve(service: "reviews")
+}
+
+interface StoreAccount {
+    createdAt: DateTime!
+    id: ID!
+}
+
+type PersonalAccount implements StoreAccount
+@owner(service: "accounts")
+{
+    createdAt: DateTime!
+    id: ID!
+    deliveryName: String!
+    dob: DateTime!
+}
+
+type BusinessAccount implements StoreAccount
+@owner(service: "accounts")
+{
+    createdAt: DateTime!
+    id: ID!
+    businessSector: String!
+    taxNumber: Int!
+    businessName: String!
 }
 
 type Mouse implements Product


### PR DESCRIPTION
This check 
``` rust
if fragment.node.type_condition.node.on.node == current_ty 
```
Was causing types who implemented interfaces to be skipped when planning the query

if you look at the test example 

the check would see if the current node matched `current_ty` in the test example this was checking that the current node matched `StoreAccount` whenever it was processing the fragment, however because the fragment acts on concrete interface types it was possible that `current_ty` would be a concrete typename such as `BusinessAccount` or `PersonalAccount` and therefore be skipped. The solution here is simply to remove this check. 

This is a bit of an edgecase as this only happens whenever the first field on a fragment is a spread for interface types. 

I was originally sceptical that this was the correct fix however all the tests still pass and we've ran graphgate with this fix against our production application and it all still works as expected. 

