### PR TITLE
Fix: Propagate full error information from upstream GraphQL

### DIFF
--- a/crates/handler/src/executor.rs
+++ b/crates/handler/src/executor.rs
@@ -51,6 +51,7 @@ impl<'e> Executor<'e> {
                     message: "Not supported".to_string(),
                     path: Default::default(),
                     locations: Default::default(),
+                    extensions: Default::default(),
                 }],
                 extensions: Default::default(),
             },
@@ -119,6 +120,7 @@ impl<'e> Executor<'e> {
                                     message: err.to_string(),
                                     path: Default::default(),
                                     locations: Default::default(),
+                                    extensions: Default::default(),
                                 }],
                                 extensions: Default::default(),
                             }
@@ -226,6 +228,7 @@ impl<'e> Executor<'e> {
                     message: err.to_string(),
                     path: Default::default(),
                     locations: Default::default(),
+                    extensions: Default::default(),
                 }),
             }
         }
@@ -458,6 +461,7 @@ impl<'e> Executor<'e> {
                         message: err.to_string(),
                         path: Default::default(),
                         locations: Default::default(),
+                        extensions: Default::default(),
                     });
                 }
             }
@@ -512,10 +516,18 @@ fn rewrite_errors(
             path.extend(err.path.drain(1..));
         }
 
+        for subpath in err.path.iter() {
+            match subpath {
+                ConstValue::String(x) => path.push(ConstValue::String(x.to_string())),
+                _ => {}
+            }
+        }
+
         target.push(ServerError {
             message: err.message,
             path,
-            locations: Default::default(),
+            locations: err.locations,
+            extensions: err.extensions,
         })
     }
 }

--- a/crates/planner/src/builder.rs
+++ b/crates/planner/src/builder.rs
@@ -69,6 +69,7 @@ impl<'a> PlanBuilder<'a> {
                         message: err.message,
                         path: Default::default(),
                         locations: err.locations,
+                        extensions: Default::default(),
                     })
                     .collect(),
                 extensions: Default::default(),

--- a/crates/planner/src/response.rs
+++ b/crates/planner/src/response.rs
@@ -20,6 +20,9 @@ pub struct ServerError {
 
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub locations: Vec<Pos>,
+
+    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
+    pub extensions: HashMap<String, ConstValue>,
 }
 
 impl ServerError {
@@ -28,6 +31,7 @@ impl ServerError {
             message: message.into(),
             path: Default::default(),
             locations: Default::default(),
+            extensions: Default::default(),
         }
     }
 }

--- a/crates/planner/src/types.rs
+++ b/crates/planner/src/types.rs
@@ -69,11 +69,11 @@ impl<'a> Display for FetchQuery<'a> {
                 )
             }
             None => {
-                write!(f, "{}\n", self.operation_type)?;
+                write!(f, "{}", self.operation_type)?;
                 if !self.variable_definitions.variables.is_empty() {
-                    write!(f, "({})\n", self.variable_definitions)?;
+                    write!(f, "({})", self.variable_definitions)?;
                 }
-                write!(f, "{}", self.selection_set)
+                write!(f, "\n{}", self.selection_set)
             }
         }
     }

--- a/crates/planner/src/types.rs
+++ b/crates/planner/src/types.rs
@@ -69,11 +69,11 @@ impl<'a> Display for FetchQuery<'a> {
                 )
             }
             None => {
-                write!(f, "{}", self.operation_type)?;
+                write!(f, "{}\n", self.operation_type)?;
                 if !self.variable_definitions.variables.is_empty() {
-                    write!(f, "({})", self.variable_definitions)?;
+                    write!(f, "({})\n", self.variable_definitions)?;
                 }
-                write!(f, " {}", self.selection_set)
+                write!(f, "{}", self.selection_set)
             }
         }
     }

--- a/crates/planner/tests/fragment_on_interface.txt
+++ b/crates/planner/tests/fragment_on_interface.txt
@@ -27,5 +27,5 @@ fragment AccountDetails on StoreAccount {
 {
     "type": "fetch",
     "service": "accounts",
-    "query": "query { me { id username storeAccount { ... on PersonalAccount { id createdAt __typename deliveryName dob } ... on BusinessAccount { id createdAt __typename taxNumber businessSector } } } }"
+    "query": "query\n{ me { id username storeAccount { ... on PersonalAccount { id createdAt __typename deliveryName dob } ... on BusinessAccount { id createdAt __typename taxNumber businessSector } } } }"
 }

--- a/crates/planner/tests/fragment_spread.txt
+++ b/crates/planner/tests/fragment_spread.txt
@@ -13,5 +13,5 @@ fragment A on User {
 {
     "type": "fetch",
     "service": "accounts",
-    "query": "query { me { id username } }"
+    "query": "query\n{ me { id username } }"
 }

--- a/crates/planner/tests/inline_fragment.txt
+++ b/crates/planner/tests/inline_fragment.txt
@@ -9,5 +9,5 @@
 {
     "type": "fetch",
     "service": "accounts",
-    "query": "query { me { id username } }"
+    "query": "query\n{ me { id username } }"
 }

--- a/crates/planner/tests/mutation.txt
+++ b/crates/planner/tests/mutation.txt
@@ -27,17 +27,17 @@ mutation {
         {
             "type": "fetch",
             "service": "accounts",
-            "query": "mutation { u1:createUser(username: \"u1\") { id username } u2:createUser(username: \"u2\") { id username } }"
+            "query": "mutation\n{ u1:createUser(username: \"u1\") { id username } u2:createUser(username: \"u2\") { id username } }"
         },
         {
             "type": "fetch",
             "service": "reviews",
-            "query": "mutation { review1:createReview(body: \"hehe\") { body } review2:createReview(body: \"haha\") { body } }"
+            "query": "mutation\n{ review1:createReview(body: \"hehe\") { body } review2:createReview(body: \"haha\") { body } }"
         },
         {
             "type": "fetch",
             "service": "accounts",
-            "query": "mutation { u3:createUser(username: \"u3\") { id username } }"
+            "query": "mutation\n{ u3:createUser(username: \"u3\") { id username } }"
         }
     ]
 }

--- a/crates/planner/tests/node_fragments.txt
+++ b/crates/planner/tests/node_fragments.txt
@@ -29,5 +29,5 @@ query($nodeId: ID!){
     "variables": {
         "nodeId": "6be94a2d-34d0-45fb-927e-42abd3552007"
     },
-    "query": "query($nodeId: ID!) { node(id: $nodeId) { ... on PersonalAccount { id __typename dob deliveryName } ... on BusinessAccount { id __typename taxNumber businessSector } } }"
+    "query": "query($nodeId: ID!)\n{ node(id: $nodeId) { ... on PersonalAccount { id __typename dob deliveryName } ... on BusinessAccount { id __typename taxNumber businessSector } } }"
 }

--- a/crates/planner/tests/possible_interface.txt
+++ b/crates/planner/tests/possible_interface.txt
@@ -14,7 +14,7 @@
         {
             "type": "fetch",
             "service": "products",
-            "query": "query { topProducts { ... on Mouse { upc name price } ... on Book { upc __key1___typename:__typename __key1_upc:upc } ... on Car { upc __key2___typename:__typename __key2_upc:upc } } }"
+            "query": "query\n{ topProducts { ... on Mouse { upc name price } ... on Book { upc __key1___typename:__typename __key1_upc:upc } ... on Car { upc __key2___typename:__typename __key2_upc:upc } } }"
         },
         {
             "type": "parallel",
@@ -63,7 +63,7 @@
         {
             "type": "fetch",
             "service": "products",
-            "query": "query { topProducts { ... on Mouse { upc name price isWireless } ... on Book { upc __key1___typename:__typename __key1_upc:upc } ... on Car { upc __key2___typename:__typename __key2_upc:upc } } }"
+            "query": "query\n{ topProducts { ... on Mouse { upc name price isWireless } ... on Book { upc __key1___typename:__typename __key1_upc:upc } ... on Car { upc __key2___typename:__typename __key2_upc:upc } } }"
         },
         {
             "type": "parallel",

--- a/crates/planner/tests/possible_union.txt
+++ b/crates/planner/tests/possible_union.txt
@@ -29,7 +29,7 @@
         {
             "type": "fetch",
             "service": "accounts",
-            "query": "query { me { __key1___typename:__typename __key1_id:id } }"
+            "query": "query\n{ me { __key1___typename:__typename __key1_id:id } }"
         },
         {
             "type": "flatten",

--- a/crates/planner/tests/query.txt
+++ b/crates/planner/tests/query.txt
@@ -17,5 +17,5 @@
 {
     "type": "fetch",
     "service": "accounts",
-    "query": "query { u1:user(id: \"1234\") { id username } me { id username } u2:user(id: \"1234\") { id username } myName theirName(id: 42) }"
+    "query": "query\n{ u1:user(id: \"1234\") { id username } me { id username } u2:user(id: \"1234\") { id username } myName theirName(id: 42) }"
 }

--- a/crates/planner/tests/subscribe.txt
+++ b/crates/planner/tests/subscribe.txt
@@ -13,7 +13,7 @@ subscription {
     "subscribeNodes": [
         {
             "service": "accounts",
-            "query": "subscription { users { id username __key1___typename:__typename __key1_id:id } }"
+            "query": "subscription\n{ users { id username __key1___typename:__typename __key1_id:id } }"
         }
     ],
     "flattenNode": {

--- a/crates/planner/tests/variables.txt
+++ b/crates/planner/tests/variables.txt
@@ -19,7 +19,7 @@ query($u1: ID!, $u2: ID!) {
         "u1": "user1",
         "u2": "user2"
     },
-    "query": "query($u1: ID!, $u2: ID!) { u1:user(id: $u1) { id username } u2:user(id: $u2) { id username } }"
+    "query": "query($u1: ID!, $u2: ID!)\n{ u1:user(id: $u1) { id username } u2:user(id: $u2) { id username } }"
 }
 ---
 fragment A on Query {
@@ -42,7 +42,7 @@ query($id: ID!) {
     "variables": {
         "id": "user1"
     },
-    "query": "query($id: ID!) { user(id: $id) { id username } }"
+    "query": "query($id: ID!)\n{ user(id: $id) { id username } }"
 }
 ---
 query($id: ID!) {
@@ -63,5 +63,5 @@ query($id: ID!) {
     "variables": {
         "id": "user1"
     },
-    "query": "query($id: ID!) { user(id: $id) { id username } }"
+    "query": "query($id: ID!)\n{ user(id: $id) { id username } }"
 }


### PR DESCRIPTION
# Description
This extends the ServerError data model to include an extensions field (to line up with what the upstream GraphQL service sends). This also modifies the rewrite_errors function to pass through the `path`, `extensions`, and `locations` of the received error. Finally, I modify the formatting of the FetchQuery Display trait implementation to better represent the received query for accurate `locations` data of the error

This is to address and close #8 