### PR TITLE
Feature: Add gateway_name for Kubernetes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,9 @@ pub struct Config {
     pub bind: String,
 
     #[serde(default)]
+    pub gateway_name: String,
+
+    #[serde(default)]
     pub services: Vec<ServiceConfig>,
 
     #[serde(default)]


### PR DESCRIPTION
# Description
This enhances the Kubernetes implementation by adding a label called "graphgate.org/gateway". This acts as an filter when multiple instances of graphgate are running in a namespace, such that particular services can declare they are part of a "gateway". 

This should ease some multi-tenanted scenarios where making multiple namespaces isn't feasible. If the "gateway_name" parameter is not available in the configuration, it defaults back to the standard behavior (of filtering for the presence of graphgate.org/service being a present label on a service). 