### PR TITLE
Feat: Forward Headers set by Upstream GraphQL Services

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,9 @@ bind = "0.0.0.0:8000"
 # Forward headers to upstream services.
 forward_headers = []
 
+# Receive headers from upstream service and send to client
+receive_headers = []
+
 ## Optional CORS config
 ## If allow_any_origin is set to true it will override any origins set using the allow_origins option
 # [cors]

--- a/crates/handler/src/executor.rs
+++ b/crates/handler/src/executor.rs
@@ -54,6 +54,7 @@ impl<'e> Executor<'e> {
                     extensions: Default::default(),
                 }],
                 extensions: Default::default(),
+                headers: Default::default(),
             },
         }
     }
@@ -123,6 +124,7 @@ impl<'e> Executor<'e> {
                                     extensions: Default::default(),
                                 }],
                                 extensions: Default::default(),
+                                headers: Default::default(),
                             }
                         })
                     }
@@ -219,6 +221,7 @@ impl<'e> Executor<'e> {
                 Ok(mut resp) => {
                     if resp.errors.is_empty() {
                         add_tracing_spans(&mut resp);
+                        current_resp.headers = resp.headers;
                         merge_data(&mut current_resp.data, resp.data);
                     } else {
                         rewrite_errors(None, &mut current_resp.errors, resp.errors);

--- a/crates/handler/src/service_route.rs
+++ b/crates/handler/src/service_route.rs
@@ -83,14 +83,22 @@ impl ServiceRouteTable {
             }
         };
 
-        let resp = HTTP_CLIENT
+        let raw_resp = HTTP_CLIENT
             .post(&url)
             .headers(header_map.cloned().unwrap_or_default())
             .json(&request)
             .send()
             .and_then(|res| async move { res.error_for_status() })
-            .and_then(|res| res.json::<Response>())
             .await?;
+
+        let mut headers: HashMap<String, String> = HashMap::new();
+
+        for (key, val) in raw_resp.headers().iter() {
+            headers.insert(key.as_str().to_string(), val.to_str().unwrap().to_string());
+        }
+
+        let mut resp = raw_resp.json::<Response>().await?;
+        resp.headers = Some(headers);
         Ok(resp)
     }
 }

--- a/crates/handler/src/websocket/server.rs
+++ b/crates/handler/src/websocket/server.rs
@@ -70,6 +70,7 @@ pub async fn server(
                                         data: ConstValue::Null,
                                         errors: vec![ServerError::new(err.to_string())],
                                         extensions: Default::default(),
+                                        headers: Default::default()
                                     };
                                     let data = ServerMessage::Data { id, payload: resp };
                                     sink.send(Message::text(serde_json::to_string(&data).unwrap())).await.ok();

--- a/crates/planner/src/builder.rs
+++ b/crates/planner/src/builder.rs
@@ -73,6 +73,7 @@ impl<'a> PlanBuilder<'a> {
                     })
                     .collect(),
                 extensions: Default::default(),
+                headers: Default::default(),
             });
         }
         Ok(())

--- a/crates/planner/src/response.rs
+++ b/crates/planner/src/response.rs
@@ -45,4 +45,7 @@ pub struct Response {
 
     #[serde(skip_serializing_if = "HashMap::is_empty", default)]
     pub extensions: HashMap<String, ConstValue>,
+
+    #[serde(skip_serializing)]
+    pub headers: Option<HashMap<String, String>>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,9 @@ pub struct Config {
     #[serde(default)]
     pub forward_headers: Vec<String>,
 
+    #[serde(default)]
+    pub receive_headers: Vec<String>,
+
     pub jaeger: Option<JaegerConfig>,
 
     pub cors: Option<CorsConfig>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,10 +118,11 @@ async fn main() -> Result<()> {
     let _uninstall = init_tracer(&config)?;
     let exporter = opentelemetry_prometheus::exporter().init();
 
-    let shared_route_table = SharedRouteTable::default();
+    let mut shared_route_table = SharedRouteTable::default();
     if !config.services.is_empty() {
         tracing::info!("Route table in the configuration file.");
         shared_route_table.set_route_table(config.create_route_table());
+        shared_route_table.set_receive_headers(config.receive_headers);
     } else if std::env::var("KUBERNETES_SERVICE_HOST").is_ok() {
         tracing::info!("Route table within the current namespace in Kubernetes cluster.");
         tokio::spawn(update_route_table_in_k8s(shared_route_table.clone()));


### PR DESCRIPTION
# Description
This allows upstream GraphQL services to set headers (e.g. set-cookie, custom headers) and have GraphGate successfully proxy those out to a client. This is mainly to enable API design patterns like Double Submit Cookies, where you need to sent both a "set-cookie" and another header (e.g. Authorization) to the client. As it stands, GraphGate currently doesn't allow any headers (or cookies) to flow from an upstream service to client and this hopefully remedies that. 

The feature works 2 fold:
- The Response object has been extended such that a "headers" HashMap can be carried around. This field is never serialized by serde (and is marked as such)
- Configuration has been updated to define an "allowlist" of headers which can be set from the upstream (for example, we probably don't want to set the content-length from the upstream)
- When the final HTTPResponse is constructed in GraphGate, we iterate the HashMap of headers collected and set them on the HTTPResponse if they are in the allowlist