### PR TITLE
Fix: Allow GraphGate to pass through multi-value-headers

### DIFF
--- a/crates/handler/src/service_route.rs
+++ b/crates/handler/src/service_route.rs
@@ -99,7 +99,10 @@ impl ServiceRouteTable {
                     x.push(val.to_str().unwrap().to_string());
                 }
                 None => {
-                    headers.insert(key.as_str().to_string(), vec![val.to_str().unwrap().to_string()]);
+                    headers.insert(
+                        key.as_str().to_string(),
+                        vec![val.to_str().unwrap().to_string()],
+                    );
                 }
             }
         }

--- a/crates/handler/src/service_route.rs
+++ b/crates/handler/src/service_route.rs
@@ -91,10 +91,17 @@ impl ServiceRouteTable {
             .and_then(|res| async move { res.error_for_status() })
             .await?;
 
-        let mut headers: HashMap<String, String> = HashMap::new();
+        let mut headers: HashMap<String, Vec<String>> = HashMap::new();
 
         for (key, val) in raw_resp.headers().iter() {
-            headers.insert(key.as_str().to_string(), val.to_str().unwrap().to_string());
+            match headers.get_mut(key.as_str()) {
+                Some(x) => {
+                    x.push(val.to_str().unwrap().to_string());
+                }
+                None => {
+                    headers.insert(key.as_str().to_string(), vec![val.to_str().unwrap().to_string()]);
+                }
+            }
         }
 
         let mut resp = raw_resp.json::<Response>().await?;

--- a/crates/handler/src/shared_route_table.rs
+++ b/crates/handler/src/shared_route_table.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::{Context, Error, Result};
 use graphgate_planner::{PlanBuilder, Request, Response, ServerError};
 use graphgate_schema::ComposedSchema;
+use http::{header::HeaderName, HeaderValue};
 use opentelemetry::trace::{TraceContextExt, Tracer};
 use opentelemetry::{global, Context as OpenTelemetryContext};
 use serde::Deserialize;
@@ -10,7 +11,6 @@ use tokio::sync::{mpsc, RwLock};
 use tokio::time::{Duration, Instant};
 use value::ConstValue;
 use warp::http::{HeaderMap, Response as HttpResponse, StatusCode};
-use http::{HeaderValue, header::HeaderName};
 
 use crate::executor::Executor;
 use crate::fetcher::HttpFetcher;
@@ -196,9 +196,15 @@ impl SharedRouteTable {
 
         match resp.headers.clone() {
             Some(x) => {
-                for (k, v) in x.into_iter().filter(|(k, _v)| self.receive_headers.contains(k)) {
+                for (k, v) in x
+                    .into_iter()
+                    .filter(|(k, _v)| self.receive_headers.contains(k))
+                {
                     for val in v {
-                        header_map.append(HeaderName::from_bytes(k.as_bytes()).unwrap(), HeaderValue::from_str(&val).unwrap());
+                        header_map.append(
+                            HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                            HeaderValue::from_str(&val).unwrap(),
+                        );
                     }
                 }
             }
@@ -206,9 +212,7 @@ impl SharedRouteTable {
         }
 
         match builder.headers_mut() {
-            Some(x) => {
-                x.extend(header_map)
-            },
+            Some(x) => x.extend(header_map),
             None => {}
         }
 

--- a/crates/planner/src/response.rs
+++ b/crates/planner/src/response.rs
@@ -47,5 +47,5 @@ pub struct Response {
     pub extensions: HashMap<String, ConstValue>,
 
     #[serde(skip_serializing)]
-    pub headers: Option<HashMap<String, String>>,
+    pub headers: Option<HashMap<String, Vec<String>>>,
 }


### PR DESCRIPTION
# Description
This allows graphgate to forward along headers which may have multiple values (i.e. set-cookies)