### PR TITLE
eliminate warnings of clippy

### DIFF
--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -30,7 +30,7 @@ fn get_annotation_value<'a>(meta: &'a ObjectMeta, name: &str) -> Option<&'a str>
 }
 
 fn get_gateway_or_default(gateway_name: &str) -> String {
-    match gateway_name.len() > 0 {
+    match !gateway_name.is_empty() {
         true => {
             tracing::trace!(
                 "Found gateway name: {}. Looking for gateway labels instead.",
@@ -71,8 +71,7 @@ pub async fn find_graphql_services(gateway_name: &str) -> Result<ServiceRouteTab
             for service_port in service
                 .spec
                 .iter()
-                .map(|spec| spec.ports.iter())
-                .flatten()
+                .flat_map(|spec| spec.ports.iter())
                 .flatten()
             {
                 let tls = get_annotation_value(&service.metadata, ANNOTATIONS_TLS).is_some();


### PR DESCRIPTION
```
length comparison to zero
`#[warn(clippy::[len_zero](https://rust-lang.github.io/rust-clippy/master/index.html#len_zero))]` on by default
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zeroclippylen_zero
k8s.rs(33, 11): using `!is_empty` is clearer and more explicit: `!gateway_name.is_empty()`
```

```
called `map(..).flatten()` on an `Iterator`
`#[warn(clippy::[map_flatten](https://rust-lang.github.io/rust-clippy/master/index.html#map_flatten))]` on by default
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_flattenclippymap_flatten
k8s.rs(73, 24): try using `flat_map` instead: `.flat_map(|spec| spec.ports.iter())`
```
